### PR TITLE
Change operator to raise AirflowFailException when check does not pass

### DIFF
--- a/src/airflow/providers/anomalo/operators/anomalo.py
+++ b/src/airflow/providers/anomalo/operators/anomalo.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from typing import Callable, Mapping, Optional
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.models import BaseOperator
 from airflow.providers.anomalo.hooks.anomalo import AnomaloHook
 
@@ -61,7 +61,7 @@ class AnomaloCheckRunResultOperator(BaseOperator):
         results = self.api_client.get_run_result(job_id=my_job_id)
 
         if not self.status_checker(results):
-            raise AirflowException("Anomolo Job did not pass status check")
+            raise AirflowFailException("Anomolo Job did not pass status check")
 
         return results
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -3,7 +3,7 @@ import pytest
 
 from datetime import date
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.providers.anomalo.operators.anomalo import (
     AnomaloPassFailOperator,
     AnomaloRunCheckOperator,
@@ -53,7 +53,7 @@ def test_check_run_result_operator(mocker, status_checker, expect_passes):
     try:
         results = check_run.execute(context=None)
         actual_passes = True
-    except AirflowException:
+    except AirflowFailException:
         actual_passes = False
 
     mock_client.get_table_information.assert_called_with(table_name="foo")


### PR DESCRIPTION
This PR changes the behavior of `AnomaloCheckRunResultOperator` and `AnomaloPassFailOperator` to raise an `AirflowFailException` instead of `AirflowException`. This will mark the task ask failed immediately and prevents retries.

# Why?

In our Airflow environment we have all tasks configured to have 4 tries. For sensors and operators that check the result of a previous operation, there is no value in retrying as the result will be the same unless the whole set of tasks is tried again. The automated retries even if the anomalo check has failed creates operational noise and increases the time between failed check and the team getting alerted.

In our case we see delays of up to 30 minutes (amount of retries and time between), which increases our response time to issues significantly. Our current workaround is to disable retries, however I think there is value in having this task fail immediately without explicit configuration.

# Review Notes

n/a
